### PR TITLE
Cleaned up a bit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 venv/
+redis-stable/
 
 *.pyc
 __pycache__/

--- a/app/celery_app.py
+++ b/app/celery_app.py
@@ -1,4 +1,0 @@
-from toy.app import init_celery
-
-app = init_celery()
-# app.conf.imports = app.conf.imports + ("toy.tasks.example",)

--- a/app/celery_utils.py
+++ b/app/celery_utils.py
@@ -1,8 +1,0 @@
-def init_celery(celery, app):
-    celery.conf.update(app.config)
-    TaskBase = celery.Task
-    class ContextTask(TaskBase):
-        def __call__(self, *args, **kwargs):
-            with app.app_context():
-                return TaskBase.__call__(self, *args, **kwargs)
-    celery.Task = ContextTask


### PR DESCRIPTION
We removed celery_app and celery_utils. Multiple definitions and references that were not needed in final Socket-IO version.